### PR TITLE
Added TCP serial port server as source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,13 +8,13 @@ Distributed under terms of the GPLv3
 
 ### Installation
 
-1) install the the driver
+#### 1) Install the the driver
 
 ```
 weectl extension install https://github.com/OH2LAK/weewx-wxt5x0/archive/master.zip
 ```
 
-2) configure weeWX to use the driver
+#### 2) Configure weeWX to use the driver
 ```
 weectl station reconfigure
 ```
@@ -24,9 +24,10 @@ weectl station reconfigure
 > ln -s /etc/weewx/bin/user/wxt5x0.py /usr/share/weewx/weewx/drivers/wxt5x0.py
 > ```
 > For some reason the user driver installation path is not visible for the configuration script, this symbolic linking will link the installed user driver to the built-in driver directory to enable the configuration of the wxt5x0 driver.
+>
+> Rerun the command `weectl station reconfigure` after linking and the wxt5x0 driver should be visible as 13th driver on the list
 
-
-3) restart weeWX
+#### 3) Restart weeWX
 ```
 sudo systemctl restart weewx
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,32 @@
+## wxt5x0 - driver for Vaisala WXT-series Weather Transmitters for WeeWX
+
+Copyright 2017-2024 Matthew Wall
+
+Modifications by Erik Finskas 2024 to add TCP option to connect to a TCP serial server instead of using a local serial port
+
+Distributed under terms of the GPLv3
+
+### Installation
+
+1) install the the driver
+
+```
+weectl extension install https://github.com/OH2LAK/weewx-wxt5x0/archive/master.zip
+```
+
+2) configure weeWX to use the driver
+```
+weectl station reconfigure
+```
+> [!TIP]
+> If you are having difficulties getting the WXT5x0 driver to show on the list of available drivers use this workaround:
+> ```
+> ln -s /etc/weewx/bin/user/wxt5x0.py /usr/share/weewx/weewx/drivers/wxt5x0.py
+> ```
+> For some reason the user driver installation path is not visible for the configuration script, this symbolic linking will link the installed user driver to the built-in driver directory to enable the configuration of the wxt5x0 driver.
+
+
+3) restart weeWX
+```
+sudo systemctl restart weewx
+```

--- a/bin/user/wxt5x0.py
+++ b/bin/user/wxt5x0.py
@@ -433,6 +433,64 @@ class StationTCP(Station):
             line = line.replace(b'\x00', b'')  # eliminate any NULL characters
         return line
 
+class WXT5x0ConfigurationEditor(weewx.drivers.AbstractConfEditor):
+    @property
+    def default_stanza(self):
+        return """
+[WXT5x0]
+    # This section is for Vaisala WXT5x0 stations
+
+    # The station model such as WXT510 or WXT520
+    model = WXT520
+
+    # The communication protocol to use, one of serial, nmea, sdi12 or tcp
+    protocol = serial
+
+    # The port to which the station is connected
+    port = /dev/ttyUSB0
+
+    # The device address
+    address = 0
+
+    # The TCP address of the serial port server (if using TCP)
+    tcp_address = localhost
+
+    # The TCP port of the serial port server (if using TCP)
+    # Default is 5000
+    tcp_port = 5000
+
+    # The driver to use
+    driver = user.wxt5x0
+"""
+
+    def prompt_for_settings(self):
+        print("Specify the model (WXT510 or WXT520)")
+        model = self._prompt('model', 'WXT520', ['WXT510', 'WXT520'])
+        
+        print("Specify the protocol (serial, nmea, sdi12 or tcp)")
+        protocol = self._prompt('protocol', 'serial', ['serial', 'nmea', 'sdi12', 'tcp'])
+        
+        if protocol == 'tcp':
+            print("Specify the TCP address of the serial port server")
+            tcp_address = self._prompt('tcp_address', 'localhost')
+            
+            print("Specify the TCP port of the serial port server")
+            tcp_port = self._prompt('tcp_port', 5000)
+            
+            print("Specify the device address")
+            address = self._prompt('address', 0)
+            
+            return {'model': model, 'protocol': protocol, 'tcp_address': tcp_address, 'tcp_port': tcp_port, 'address': address}
+        
+        else:
+            print("Specify the serial port on which the station is connected, for example /dev/ttyUSB0 or /dev/ttyS0.")
+            port = self._prompt('port', '/dev/ttyUSB0')
+            
+            print("Specify the device address")
+            address = self._prompt('address', 0)
+            
+            return {'model': model, 'protocol': protocol, 'port': port, 'address': address}
+
 class WXT5x0Driver(weewx.drivers.AbstractDevice):
     STATION = {
         'sdi12': StationSDI12,
@@ -601,6 +659,7 @@ if __name__ == '__main__':
                               tcp_address=options.tcp_address,
                               tcp_port=options.tcp_port,
                               poll_interval=options.poll_interval,
+                              address=options.address,
                               max_tries=3,
                               retry_wait=10,
                               timeout=5)

--- a/bin/user/wxt5x0.py
+++ b/bin/user/wxt5x0.py
@@ -487,7 +487,7 @@ class WXT5x0Driver(weewx.drivers.AbstractDevice):
         'heatingVoltage': 'heating_voltage',
         'supplyVoltage': 'supply_voltage',
         'referenceVoltage': 'reference_voltage',
-        }
+    }
 
     def __init__(self, **stn_dict):
         loginf('driver version is %s' % DRIVER_VERSION)
@@ -503,8 +503,13 @@ class WXT5x0Driver(weewx.drivers.AbstractDevice):
         baud = WXT5x0Driver.STATION[protocol].DEFAULT_BAUD
         baud = int(stn_dict.get('baud', baud))
         port = stn_dict.get('port', WXT5x0Driver.DEFAULT_PORT)
+        tcp_address = stn_dict.get('tcp_address', 'localhost')
+        tcp_port = int(stn_dict.get('tcp_port', 5000))
         self.last_rain_total = None
-        self._station = WXT5x0Driver.STATION.get(protocol)(address, port, baud)
+        if protocol == 'tcp':
+            self._station = WXT5x0Driver.STATION.get(protocol)(tcp_address, tcp_port)
+        else:
+            self._station = WXT5x0Driver.STATION.get(protocol)(address, port, baud)
         self._station.open()
 
     def closePort(self):
@@ -513,7 +518,7 @@ class WXT5x0Driver(weewx.drivers.AbstractDevice):
     @property
     def hardware_name(self):
         return self._model
-                    
+
     def genLoopPackets(self):
         while True:
             for cnt in range(self._max_tries):
@@ -596,6 +601,10 @@ if __name__ == '__main__':
                       help='baud rate', default=19200)
     parser.add_option('--address', type=int,
                       help='device address', default=0)
+    parser.add_option('--tcp_address',
+                      help='TCP address', default='localhost')
+    parser.add_option('--tcp_port', type=int,
+                      help='TCP port', default=5000)
     parser.add_option('--poll-interval', metavar='POLL', type=int,
                       help='poll interval, in seconds', default=3)
     parser.add_option('--get-wind',
@@ -617,13 +626,12 @@ if __name__ == '__main__':
     elif options.protocol == 'tcp':
         driver = WXT5x0Driver(model='WXT520',
                               protocol=options.protocol,
-                              port=options.port,
-                              address=options.address,
+                              tcp_address=options.tcp_address,
+                              tcp_port=options.tcp_port,
                               poll_interval=options.poll_interval,
                               max_tries=3,
                               retry_wait=10,
-                              timeout=5,
-                              baudrate=options.baud)
+                              timeout=5)
     else:
         driver = WXT5x0Driver(model='WXT520',
                               protocol=options.protocol,

--- a/bin/user/wxt5x0.py
+++ b/bin/user/wxt5x0.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2017-2024 Matthew Wall, all rights reserved
 # Distributed under terms of the GPLv3
-# Modified by: Erik Finskas OH2LAK 2024 to support TCP/IP connection via TCP serial server
+# Modified by: Erik Finskas OH2LAK 2024 to support TCP/IP connection via TCP serial server instead of local serial port
 """
 Collect data from Vaisala WXT510 or WXT520 station.
 

--- a/bin/user/wxt5x0.py
+++ b/bin/user/wxt5x0.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2017-2024 Matthew Wall, all rights reserved
 # Distributed under terms of the GPLv3
-# Modified by: Erik Finskas OH2LAK 2024 to support TCP/IP connection to Vaisala WXT5x0
+# Modified by Erik Finskas OH2LAK 2024 to support remote TCP serial port server instead of a local serial port
 """
 Collect data from Vaisala WXT510 or WXT520 station.
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+0.8 28Dec2024
+* Added possibility to connect directly to a TCP serial port server instead using a local serial port
+
 0.7 21feb2024
 * fixed rain calculation when rain_total is None
 

--- a/install.py
+++ b/install.py
@@ -1,5 +1,6 @@
 # installer for wxt5x0 driver
 # Copyright 2017-2024 Matthew Wall
+# Modified by Erik Finskas 2024
 # Distributed under terms of the GPLv3
 
 from weecfg.extension import ExtensionInstaller
@@ -10,7 +11,7 @@ def loader():
 class WXT5x0Installer(ExtensionInstaller):
     def __init__(self):
         super(WXT5x0Installer, self).__init__(
-            version="0.7",
+            version="0.8",
             name='wxt5x0',
             description='Collect data from WXT5x0 hardware',
             author="Matthew Wall",

--- a/readme
+++ b/readme
@@ -1,6 +1,6 @@
 wxt5x0
 Copyright 2017-2024 Matthew Wall
-Modifications by Erik Finskas 2024 to add TCP connection
+Modifications by Erik Finskas 2024 to add TCP option to connect to a TCP serial server instead of using a local serial port
 Distributed under terms of the GPLv3
 
 This is a driver for weeWX that collects data from Vaisala WXT5x0 hardware.

--- a/readme
+++ b/readme
@@ -1,5 +1,6 @@
 wxt5x0
 Copyright 2017-2024 Matthew Wall
+Modifications by Erik Finskas 2024 to add TCP connection
 Distributed under terms of the GPLv3
 
 This is a driver for weeWX that collects data from Vaisala WXT5x0 hardware.
@@ -9,7 +10,7 @@ Installation
 
 1) install the the driver
 
-  weectl extension install https://github.com/matthewwall/weewx-wxt5x0/archive/master.zip
+  weectl extension install https://github.com/OH2LAK/weewx-wxt5x0/archive/master.zip
 
 2) configure weeWX to use the driver
 

--- a/readme
+++ b/readme
@@ -1,4 +1,5 @@
-wxt5x0
+Vaisala wxt5x0 driver for WeeWX
+
 Copyright 2017-2024 Matthew Wall
 Modifications by Erik Finskas 2024 to add TCP option to connect to a TCP serial server instead of using a local serial port
 Distributed under terms of the GPLv3
@@ -19,3 +20,7 @@ Installation
 3) restart weeWX
 
   sudo systemctl restart weewx
+
+If you are having difficulties getting the WXT5x0 driver to show on the list of available drivers,
+use this workaround: (For some reason the user driver installation path is not visible for the configuration script)
+ln -s /etc/weewx/bin/user/wxt5x0.py /usr/share/weewx/weewx/drivers/wxt5x0.py


### PR DESCRIPTION
I added tcp as 'port' option to use a network serial port server as data source instead of local serial port. The solution has been tested with a Moxa NPort serial port server running in TCP server mode, and with a Mikrotik router with a USB-RS232 dongle connected to its USB port as per this article: https://jcutrer.com/howto/networking/mikrotik/mikrotik-scada-serial-server